### PR TITLE
add YOCTO option to CMakeLists

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,6 +18,7 @@ endif()
 enable_language(C)
 enable_testing()
 
+option(YOCTO "Enable Building in Yocto" OFF)
 option(TRINARY_TEST "Trinary tests" OFF)
 
 #Trit Encoding flags
@@ -35,17 +36,20 @@ option(TE_5 "Trit encoding 5 trits per byte" OFF)
 
 set(THREADS_PREFER_PTHREAD_FLAG ON)
 find_package(Threads REQUIRED)
-include(ExternalProject)
 
-# libs in the sandbox
-#link_directories("${PROJECT_BINARY_DIR}/lib")
-link_directories("${CMAKE_INSTALL_PREFIX}/lib")
+if(NOT YOCTO)
+  include(ExternalProject)
 
-# external libs
-include(cmake/embear_logger.cmake)
-include(cmake/keccak.cmake)
-include(cmake/unity.cmake)
-include(cmake/uthash.cmake)
+  # libs in the sandbox
+  #link_directories("${PROJECT_BINARY_DIR}/lib")
+  link_directories("${CMAKE_INSTALL_PREFIX}/lib")
+
+  # external libs
+  include(cmake/embear_logger.cmake)
+  include(cmake/keccak.cmake)
+  include(cmake/unity.cmake)
+  include(cmake/uthash.cmake)
+endif()
 
 set(COMMON_TRINARY_DIR "common/trinary")
 set(COMMON_CRYPTO_DIR "common/crypto")
@@ -154,11 +158,13 @@ target_include_directories(common PUBLIC
   "${CMAKE_INSTALL_PREFIX}/include"
 )
 
-add_dependencies(common
-  ext_uthash
-  ext_keccak
-  ext_embear_logger
-)
+if(NOT YOCTO)
+  add_dependencies(common
+    ext_uthash
+    ext_keccak
+    ext_embear_logger
+  )
+endif()
 
 target_link_libraries(common PUBLIC 
   Threads::Threads


### PR DESCRIPTION
this makes integration with the meta-iota Yocto/OpenEmbedded layer easier, as I don't have to patch CMakeLists.txt locally.